### PR TITLE
Update plugin to work with newer versions of Jekyll that use Liquid v4+

### DIFF
--- a/_plugins/jekyllgram.rb
+++ b/_plugins/jekyllgram.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Jekyllgram
 #
@@ -33,13 +35,11 @@ require 'json'
 module Jekyll
   # _plugins/jekyllgram.rb
   class Jekyllgram < Liquid::Block
-
     include Liquid::StandardFilters
 
     def initialize(tag, params, token)
       @limit = params.to_i
-      @user_id = ENV['JEKYLLGRAM_USER']
-      @client_id = ENV['JEKYLLGRAM_KEY']
+      @access_token = ENV['JEKYLLGRAM_TOKEN']
       @api_url = 'https://api.instagram.com/v1'
 
       super
@@ -60,7 +60,7 @@ module Jekyll
       context.stack do
         photos.each_with_index do |photo, index|
           context['photo'] = photo
-          result << render_all(@nodelist, context)
+          result << @body.render(context)
 
           break if index + 1 == @limit
         end
@@ -70,14 +70,14 @@ module Jekyll
     end
 
     def recent_photos
-      method = "/users/#{@user_id}/media/recent"
-      keys = "/?client_id=#{@client_id}"
+      method = "/users/self/media/recent"
+      keys = "/?access_token=#{@access_token}"
 
       response = Net::HTTP.get_response(URI.parse(@api_url + method + keys))
       return [] unless response.is_a?(Net::HTTPSuccess)
-      
+
       response = JSON.parse(response.body)
-      
+
       response['data']
     end
   end

--- a/_plugins/jekyllgram.rb
+++ b/_plugins/jekyllgram.rb
@@ -70,7 +70,7 @@ module Jekyll
     end
 
     def recent_photos
-      method = "/users/self/media/recent"
+      method = '/users/self/media/recent'
       keys = "/?access_token=#{@access_token}"
 
       response = Net::HTTP.get_response(URI.parse(@api_url + method + keys))


### PR DESCRIPTION
This PR updates the plugin to work with Jekyll 4, which uses Liquid 4, which deprecated the `render_all` method on `Liquid::Block`. Also, Instagram updated their API, so it updates the HTTP call to use the new Instagram API requirements. 