### PR TITLE
Update the README for Instagram API Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,18 @@
 
 Jekyll Instagram aka Jekyllgram is a Jekyll plugin for displaying a feed of your recent Instagram photos.
 
-
-
 ### Installation and Setup
 
-To install this plugin into your project you will need to copy _plugins/jekyllgram.rb into the _plugins directory 
+To install this plugin into your project you will need to copy _plugins/jekyllgram.rb into the _plugins directory
 in your Jekyll project.
 
-For the plugin to work you will need to register an application with the Instagram API and then make your user id 
-and client id available as environment varibles below:
+For the plugin to work you will need to register an application with the Instagram API and then make your access token available as an environment varible like below:
 
 ```ruby
-ENV['JEKYLLGRAM_USER'] = {{ INSTAGRAM_USER_ID }}
-ENV['JEKYLLGRAM_KEY'] = {{ INSTAGRAM_CLIENT_ID }}
+ENV['JEKYLLGRAM_TOKEN'] = {{ INSTAGRAM_ACCESS_TOKEN }}
 ```
 
-
+@access_token = ENV['JEKYLLGRAM_TOKEN']
 
 ### Displaying the results in your templates
 

--- a/_plugins/jekyllgram.rb
+++ b/_plugins/jekyllgram.rb
@@ -9,11 +9,10 @@
 #
 # Setup:
 #
-# To use this plugin you will need to make your Instagram API credentials
-# available as environment variables below:
+# To use this plugin you will need to make your Instagram API access token
+# available as an environment variable like below:
 #
-# ENV['JEKYLLGRAM_USER'] = {{ INSTAGRAM_USER_ID }}
-# ENV['JEKYLLGRAM_KEY'] = {{ INSTAGRAM_CLIENT_ID }}
+# ENV['JEKYLLGRAM_TOKEN'] = {{ INSTAGRAM_ACCESS_TOKEN }}
 #
 # Usage in your templates:
 # You can replace the 6 below with the number of photos you wish to display


### PR DESCRIPTION
This PR updates the README to correctly instruct users to create only one necessary ENV variable for their Instagram API access token. ClientID and UserID are no longer needed and appear to be inferred from the access token.